### PR TITLE
Features/tiago pro sim fixes

### DIFF
--- a/agimus_demo_02_simple_pd_plus_tiago_pro/README.md
+++ b/agimus_demo_02_simple_pd_plus_tiago_pro/README.md
@@ -41,9 +41,70 @@ safety of people around.
 > [!NOTE]
 > Robot will start oscillating around it's starting point. When restarting the demo make sure robot was stopped with sufficient joint motion left, as during a re-run it might trigger joint limit safety!
 
-Launch the demo
+#### Install the linear-feedback-controller
 
+- Get an alum docker which is a mirror of the robot OS.
+- Create a workspace with the following 2 packages:
+  - https://github.com/loco-3d/linear-feedback-controller
+  - https://github.com/loco-3d/linear-feedback-controller-msgs
+- Use the pal deploy tooling to install this workspace onto the desired robot.
+  See the official PAL documentation.
+
+Further down the line this step will be useless as the linear-feedback-controller packages will be part of the debian packages available for install. Like `apt install pal-alum-linear-feedback-controller`.
+
+#### Setup the environment
+
+- In the docker install cyclonedds and mcap plugin for rosbags.
+  ```bash
+  sudo apt update
+  sudo apt install ros-humble-cyclonedds
+  sudo apt install ros-humble-rmw-cyclonedds-cpp
+  sudo apt install ros-humble-rosbag2-storage-mcap
+  ```
+- Install the tiago-pro packages:
+  ```bash
+  cd ros2_ws/src
+  git clone git@github.com/agimus-project/agimus-demos
+  vcs-import agimus-demos/tiago_pro.repos
+  ```
+- Change the network interface in the
+  `agimus-demos/agimus_demos_common/config/tiago_pro/cyclone_config.xml` with your own.
+- Copy the lfc + jse config in `/tmp` in the docker and on the robot:
+  ```bash
+  cp agimus-demos/agimus_demos_common/config/tiago_pro/* /tmp/
+  scp agimus-demos/agimus_demos_common/config/tiago_pro/* pal@tiago-pro:/tmp/
+  ```
+- Set the cyclone DDS config in bashrc in the docker.
+  The file got copied in the previous step in `/tmp/cyclone_config.xml`.
+  ```bash
+  echo "" >> ~/.bashrc
+  echo "export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp" >> ~/.bashrc
+  echo "export CYCLONEDDS_URI=/tmp/cyclone_config.xml" >> ~/.bashrc
+  echo "export ROS_DOMAIN_ID=2 # for TIAGo-Pro" >> ~/.bashrc
+  ```
+- On the robot remove the laser from the urdf: `pal robot_info set laser_model no-laser`
+- Lastly setup and build all:
+  ```bash
+  cd ~/ros2_ws
+  ./setup.sh
+  ./build.sh
+  ```
+
+#### Start the demo on the robot
+
+Restart the controller on the robot:
 ```bash
-ros2 launch agimus_demo_02_simple_pd_plus bringup.launch.py robot_ip:=<robot-ip> use_rviz:=true
+pal module_manager restart
 ```
-Expected result: after starting the demo, a RViz 2 window should be appearing with the Franka robot. The robot's joints oscillating gently.
+
+Start the demo (with `ssh -X` in remote because a terminal window will appear to start the controllers):
+```bash
+ros2 launch agimus_demo_02_simple_pd_plus_tiago_pro bringup.launch.py robot_ip:=<robot-ip> use_rviz:=true
+```
+
+This procedure spawns:
+- A RViz window with the robot.
+- A xterm that asks for pressing enter to switch to torque control.
+
+Once the user is ready with an emergency stop at hand, press enter in the xterm.
+The robot will switch from position control to torque control and its joints will oscillate gently.

--- a/agimus_demo_02_simple_pd_plus_tiago_pro/README.md
+++ b/agimus_demo_02_simple_pd_plus_tiago_pro/README.md
@@ -17,6 +17,11 @@ This demo requires source built of dependencies found in:
 > [!NOTE]
 > Gazebo simulation of tiago-pro robots require very high frequency of the simulated environment, hence users might experience high CPU utilization or even errors in cases where older and less powerful computers are used.
 
+Make sure `ROS_DOMAIN_ID` is set to avoid interference with other ROS 2 nodes on the network:
+```bash
+export ROS_DOMAIN_ID=<your_id>
+```
+
 To launch the demo run:
 
 ```bash

--- a/agimus_demo_02_simple_pd_plus_tiago_pro/README.md
+++ b/agimus_demo_02_simple_pd_plus_tiago_pro/README.md
@@ -49,9 +49,7 @@ safety of people around.
 #### Install the linear-feedback-controller
 
 - Get an alum docker which is a mirror of the robot OS.
-- Create a workspace with the following 2 packages:
-  - https://github.com/loco-3d/linear-feedback-controller
-  - https://github.com/loco-3d/linear-feedback-controller-msgs
+- run sudo apt install pal-alum-linear-feedback-controller
 - Use the pal deploy tooling to install this workspace onto the desired robot.
   See the official PAL documentation.
 
@@ -59,13 +57,6 @@ Further down the line this step will be useless as the linear-feedback-controlle
 
 #### Setup the environment
 
-- In the docker install cyclonedds and mcap plugin for rosbags.
-  ```bash
-  sudo apt update
-  sudo apt install ros-humble-cyclonedds
-  sudo apt install ros-humble-rmw-cyclonedds-cpp
-  sudo apt install ros-humble-rosbag2-storage-mcap
-  ```
 - Install the tiago-pro packages:
   ```bash
   cd ros2_ws/src

--- a/agimus_demo_02_simple_pd_plus_tiago_pro/config/pd_plus_controller_params.yaml
+++ b/agimus_demo_02_simple_pd_plus_tiago_pro/config/pd_plus_controller_params.yaml
@@ -3,7 +3,7 @@ pd_plus_controller:
   ros__parameters:
     moving_joint_names: [arm_right_1_joint, arm_right_2_joint, arm_right_3_joint, arm_right_4_joint,
       arm_right_5_joint, arm_right_6_joint, arm_right_7_joint]
-    amplitudes: [0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05]
+    amplitudes: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
     periods: [4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0]
     p_gains: [50.0, 50.0, 50.0, 50.0, 10.0, 5.0, 5.0]
     d_gains: [0.5, 0.5, 0.5, 0.5, 0.3, 0.3, 0.0]

--- a/agimus_demo_03_mpc_dummy_traj_tiago_pro/launch/bringup.launch.py
+++ b/agimus_demo_03_mpc_dummy_traj_tiago_pro/launch/bringup.launch.py
@@ -4,7 +4,7 @@ from launch.actions import (
     OpaqueFunction,
     RegisterEventHandler,
 )
-from launch.conditions import IfCondition
+from launch.conditions import IfCondition, UnlessCondition
 
 from launch.event_handlers import OnProcessExit
 from launch.launch_description_entity import LaunchDescriptionEntity
@@ -137,6 +137,7 @@ def launch_setup(
         executable="tuck_arm.py",
         parameters=[get_use_sim_time()],
         output="screen",
+        condition=UnlessCondition(use_gazebo),
     )
 
     #

--- a/agimus_demos_common/agimus_demos_common/launch_utils.py
+++ b/agimus_demos_common/agimus_demos_common/launch_utils.py
@@ -402,6 +402,26 @@ def generate_default_tiago_pro_args() -> list[DeclareLaunchArgument]:
             choices=["True", "False"],
             default_value="True",
         ),
+        DeclareLaunchArgument(
+            "lfc_pkg",
+            default_value="agimus_demos_common",
+            description="Package containing the LFC/JSE/passthrough config files for simulation.",
+        ),
+        DeclareLaunchArgument(
+            "lfc_yaml",
+            default_value="config/tiago_pro/linear_feedback_controller_simu_params.yaml",
+            description="Path relative to lfc_pkg share to the LFC params file (simulation).",
+        ),
+        DeclareLaunchArgument(
+            "jse_yaml",
+            default_value="config/tiago_pro/joint_state_estimator_simu_params.yaml",
+            description="Path relative to lfc_pkg share to the JSE params file (simulation).",
+        ),
+        DeclareLaunchArgument(
+            "pc_yaml",
+            default_value="config/tiago_pro/dummy_controllers.yaml",
+            description="Path relative to lfc_pkg share to the passthrough controllers params file (simulation).",
+        ),
     ]
 
 

--- a/agimus_demos_common/agimus_demos_common/launch_utils.py
+++ b/agimus_demos_common/agimus_demos_common/launch_utils.py
@@ -379,9 +379,10 @@ def generate_default_tiago_pro_args() -> list[DeclareLaunchArgument]:
             default_value="True",
         ),
         DeclareLaunchArgument(
-            "world_name",
-            description="Specify world name, will be converted to full path.",
-            default_value="empty",
+            "gazebo_version",
+            description="Version of Gazebo: 'gazebo' (Ignition) or 'classic'.",
+            choices=["gazebo", "classic"],
+            default_value="gazebo",
         ),
         DeclareLaunchArgument(
             "tuck_arm",
@@ -394,6 +395,12 @@ def generate_default_tiago_pro_args() -> list[DeclareLaunchArgument]:
             description="Enable public simulation.",
             choices=["True", "False"],
             default_value="False",
+        ),
+        DeclareLaunchArgument(
+            "play_motion2",
+            description="Launch play_motion2.",
+            choices=["True", "False"],
+            default_value="True",
         ),
     ]
 

--- a/agimus_demos_common/agimus_demos_common/launch_utils.py
+++ b/agimus_demos_common/agimus_demos_common/launch_utils.py
@@ -291,13 +291,13 @@ def generate_default_tiago_pro_args() -> list[DeclareLaunchArgument]:
         DeclareLaunchArgument(
             "end_effector_right",
             description="End effector model right arm.",
-            choices=["pal-pro-gripper", "custom", "no-end-effector"],
+            choices=["pal-pro-gripper", "custom", "no-end-effector", "pal-atc"],
             default_value="no-end-effector",
         ),
         DeclareLaunchArgument(
             "end_effector_left",
             description="End effector model left arm.",
-            choices=["pal-pro-gripper", "custom", "no-end-effector"],
+            choices=["pal-pro-gripper", "custom", "no-end-effector", "pal-atc"],
             default_value="no-end-effector",
         ),
         DeclareLaunchArgument(

--- a/agimus_demos_common/config/tiago_pro/joint_state_estimator_params.yaml
+++ b/agimus_demos_common/config/tiago_pro/joint_state_estimator_params.yaml
@@ -6,9 +6,9 @@ joint_state_estimator:
       arm_right_4_joint/position, arm_right_5_joint/position, arm_right_6_joint/position,
       arm_right_7_joint/position, arm_right_1_joint/velocity, arm_right_2_joint/velocity,
       arm_right_3_joint/velocity, arm_right_4_joint/velocity, arm_right_5_joint/velocity,
-      arm_right_6_joint/velocity, arm_right_7_joint/velocity, arm_right_1_joint/force, arm_right_2_joint/force,
-      arm_right_3_joint/force, arm_right_4_joint/force, arm_right_5_joint/force, arm_right_6_joint/force,
-      arm_right_7_joint/force]
+      arm_right_6_joint/velocity, arm_right_7_joint/velocity, arm_right_1_joint/effort, arm_right_2_joint/effort,
+      arm_right_3_joint/effort, arm_right_4_joint/effort, arm_right_5_joint/effort, arm_right_6_joint/effort,
+      arm_right_7_joint/effort]
     command_interfaces: [linear_feedback_controller/arm_right_1_joint/position, linear_feedback_controller/arm_right_2_joint/position,
       linear_feedback_controller/arm_right_3_joint/position, linear_feedback_controller/arm_right_4_joint/position,
       linear_feedback_controller/arm_right_5_joint/position, linear_feedback_controller/arm_right_6_joint/position,

--- a/agimus_demos_common/config/tiago_pro/linear_feedback_controller_params.yaml
+++ b/agimus_demos_common/config/tiago_pro/linear_feedback_controller_params.yaml
@@ -26,8 +26,8 @@ linear_feedback_controller:
       p: 5.0
       d: 0.0
     chainable_controller:
-      command_interfaces: [arm_right_1_joint/force, arm_right_2_joint/force, arm_right_3_joint/force,
-        arm_right_4_joint/force, arm_right_5_joint/force, arm_right_6_joint/force, arm_right_7_joint/force]
+      command_interfaces: [arm_right_1_joint/effort, arm_right_2_joint/effort, arm_right_3_joint/effort,
+        arm_right_4_joint/effort, arm_right_5_joint/effort, arm_right_6_joint/effort, arm_right_7_joint/effort]
       reference_prefix: ''
     joint_velocity_filter_coefficient: 0.9
     pd_to_lf_transition_duration: 0.1

--- a/agimus_demos_common/launch/tiago_pro/tiago_pro_common.launch.py
+++ b/agimus_demos_common/launch/tiago_pro/tiago_pro_common.launch.py
@@ -13,6 +13,7 @@ from launch.event_handlers import OnProcessExit
 from launch.launch_description_entity import LaunchDescriptionEntity
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 import os
+import yaml
 
 from launch.substitutions import (
     Command,
@@ -29,16 +30,6 @@ from agimus_demos_common.launch_utils import (
     generate_default_tiago_pro_args,
     get_use_sim_time,
 )
-
-PASSTHROUGH_CONTROLLERS = [
-    "arm_right_1_joint_inertia_shaping_controller",
-    "arm_right_2_joint_inertia_shaping_controller",
-    "arm_right_3_joint_inertia_shaping_controller",
-    "arm_right_4_joint_inertia_shaping_controller",
-    "arm_right_5_joint_inertia_shaping_controller",
-    "arm_right_6_joint_inertia_shaping_controller",
-    "arm_right_7_joint_inertia_shaping_controller",
-]
 
 
 def launch_setup(
@@ -64,12 +55,15 @@ def launch_setup(
         lfc_yaml = context.perform_substitution(LaunchConfiguration("lfc_yaml"))
         jse_yaml = context.perform_substitution(LaunchConfiguration("jse_yaml"))
         pc_yaml = context.perform_substitution(LaunchConfiguration("pc_yaml"))
+        pc_yaml_path = os.path.join(lfc_pkg_share, pc_yaml)
+        with open(pc_yaml_path) as f:
+            passthrough_controllers = list(yaml.safe_load(f).keys())
         lfc_controllers_params = [
-            os.path.join(lfc_pkg_share, pc_yaml),
+            pc_yaml_path,
             os.path.join(lfc_pkg_share, jse_yaml),
             os.path.join(lfc_pkg_share, lfc_yaml),
         ]
-        lfc_controllers = PASSTHROUGH_CONTROLLERS + lfc_controllers
+        lfc_controllers = passthrough_controllers + lfc_controllers
     else:
         lfc_controllers_params = [
             "/tmp/joint_state_estimator_params.yaml",
@@ -162,7 +156,7 @@ def launch_setup(
                 "arm_right_controller",
                 "--activate",
             ]
-            + PASSTHROUGH_CONTROLLERS
+            + passthrough_controllers
             + ["linear_feedback_controller", "joint_state_estimator"],
             output="screen",
         )
@@ -174,7 +168,7 @@ def launch_setup(
             rviz_node,
             RegisterEventHandler(
                 OnProcessExit(
-                    target_action=spawn_lfc_controllers.entities[2],
+                    target_action=spawn_lfc_controllers.entities[-1],
                     on_exit=[activate_controllers],
                 )
             ),

--- a/agimus_demos_common/launch/tiago_pro/tiago_pro_common.launch.py
+++ b/agimus_demos_common/launch/tiago_pro/tiago_pro_common.launch.py
@@ -2,15 +2,25 @@ from controller_manager.launch_utils import (
     generate_controllers_spawner_launch_description,  # noqa: I001
 )
 from launch import LaunchContext, LaunchDescription
-from launch.actions import OpaqueFunction
+from launch.actions import (
+    ExecuteProcess,
+    IncludeLaunchDescription,
+    OpaqueFunction,
+    RegisterEventHandler,
+)
 from launch.conditions import IfCondition
+from launch.event_handlers import OnProcessExit
 from launch.launch_description_entity import LaunchDescriptionEntity
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+import os
+
 from launch.substitutions import (
     Command,
     FindExecutable,
     LaunchConfiguration,
     PathJoinSubstitution,
 )
+from ament_index_python.packages import get_package_share_directory
 from launch_ros.actions import Node
 from launch_ros.parameter_descriptions import ParameterValue
 from launch_ros.substitutions import FindPackageShare
@@ -19,6 +29,16 @@ from agimus_demos_common.launch_utils import (
     generate_default_tiago_pro_args,
     get_use_sim_time,
 )
+
+PASSTHROUGH_CONTROLLERS = [
+    "arm_right_1_joint_inertia_shaping_controller",
+    "arm_right_2_joint_inertia_shaping_controller",
+    "arm_right_3_joint_inertia_shaping_controller",
+    "arm_right_4_joint_inertia_shaping_controller",
+    "arm_right_5_joint_inertia_shaping_controller",
+    "arm_right_6_joint_inertia_shaping_controller",
+    "arm_right_7_joint_inertia_shaping_controller",
+]
 
 
 def launch_setup(
@@ -31,21 +51,31 @@ def launch_setup(
     rviz_config_path = LaunchConfiguration("rviz_config_path")
 
     use_gazebo_bool = context.perform_substitution(use_gazebo).lower() == "true"
-    if use_gazebo_bool:
-        jse_file = "joint_state_estimator_simu_params.yaml"
-        lfc_file = "linear_feedback_controller_simu_params.yaml"
-    else:
-        jse_file = "joint_state_estimator_params.yaml"
-        lfc_file = "linear_feedback_controller_params.yaml"
-    lfc_controllers_params = [
-        f"/tmp/{jse_file}",  # JSE params file
-        f"/tmp/{lfc_file}",  # LFC params file
-    ]
+
     lfc_controllers = [
         "linear_feedback_controller",
         "joint_state_estimator",
     ]
-    # Spawn external controllers, namely the lfc.
+
+    if use_gazebo_bool:
+        lfc_pkg_share = get_package_share_directory(
+            context.perform_substitution(LaunchConfiguration("lfc_pkg"))
+        )
+        lfc_yaml = context.perform_substitution(LaunchConfiguration("lfc_yaml"))
+        jse_yaml = context.perform_substitution(LaunchConfiguration("jse_yaml"))
+        pc_yaml = context.perform_substitution(LaunchConfiguration("pc_yaml"))
+        lfc_controllers_params = [
+            os.path.join(lfc_pkg_share, pc_yaml),
+            os.path.join(lfc_pkg_share, jse_yaml),
+            os.path.join(lfc_pkg_share, lfc_yaml),
+        ]
+        lfc_controllers = PASSTHROUGH_CONTROLLERS + lfc_controllers
+    else:
+        lfc_controllers_params = [
+            "/tmp/joint_state_estimator_params.yaml",
+            "/tmp/linear_feedback_controller_params.yaml",
+        ]
+
     spawn_lfc_controllers = generate_controllers_spawner_launch_description(
         controller_names=lfc_controllers,
         controller_params_files=lfc_controllers_params,
@@ -54,14 +84,6 @@ def launch_setup(
             "--controller-manager-timeout",
             "10000000",
         ],
-    )
-
-    activate_controllers = Node(
-        package="agimus_demos_common",
-        executable="switch_controllers_trigger_node",
-        name="switch_controllers_trigger_node",
-        output="screen",
-        prefix="xterm -e",
     )
 
     robot_srdf_description_substitution = PathJoinSubstitution(
@@ -103,12 +125,75 @@ def launch_setup(
         condition=IfCondition(use_rviz),
     )
 
-    return [
-        spawn_lfc_controllers,
-        activate_controllers,
-        robot_srdf_publisher_node,
-        rviz_node,
-    ]
+    if use_gazebo_bool:
+        gazebo_launch = IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                [
+                    PathJoinSubstitution(
+                        [
+                            FindPackageShare("tiago_pro_gazebo"),
+                            "launch",
+                            "tiago_pro_gazebo.launch.py",
+                        ]
+                    )
+                ]
+            ),
+            launch_arguments={
+                **{
+                    arg.name: LaunchConfiguration(arg.name)
+                    for arg in generate_default_tiago_pro_args()
+                },
+                "tuck_arm": "False",
+                "is_public_sim": "True",
+                "moveit": "False",
+                "play_motion2": "False",
+            }.items(),
+        )
+
+        # Activate all at once: ros2_control sets chained mode atomically
+        # when preceding (LFC) and following (PassthroughControllers) are
+        # activated in the same switch_controllers transaction.
+        activate_controllers = ExecuteProcess(
+            cmd=[
+                "ros2",
+                "control",
+                "switch_controllers",
+                "--deactivate",
+                "arm_right_controller",
+                "--activate",
+            ]
+            + PASSTHROUGH_CONTROLLERS
+            + ["linear_feedback_controller", "joint_state_estimator"],
+            output="screen",
+        )
+
+        return [
+            gazebo_launch,
+            spawn_lfc_controllers,
+            robot_srdf_publisher_node,
+            rviz_node,
+            RegisterEventHandler(
+                OnProcessExit(
+                    target_action=spawn_lfc_controllers.entities[2],
+                    on_exit=[activate_controllers],
+                )
+            ),
+        ]
+    else:
+        activate_controllers = Node(
+            package="agimus_demos_common",
+            executable="switch_controllers_trigger_node",
+            name="switch_controllers_trigger_node",
+            output="screen",
+            prefix="xterm -e",
+        )
+
+        return [
+            spawn_lfc_controllers,
+            activate_controllers,
+            robot_srdf_publisher_node,
+            rviz_node,
+        ]
 
 
 def generate_launch_description():

--- a/agimus_demos_common/launch/tiago_pro/tiago_pro_simulation.launch.py
+++ b/agimus_demos_common/launch/tiago_pro/tiago_pro_simulation.launch.py
@@ -2,9 +2,9 @@ from launch import LaunchContext, LaunchDescription
 from launch.actions import (
     ExecuteProcess,
     IncludeLaunchDescription,
-    LogInfo,
     OpaqueFunction,
     RegisterEventHandler,
+    SetLaunchConfiguration,
 )
 from launch.event_handlers import OnProcessExit
 from launch.launch_description_entity import LaunchDescriptionEntity
@@ -36,7 +36,7 @@ def launch_setup(
                 FindPackageShare("agimus_demos_common"),
                 "config",
                 "tiago_pro",
-                "linear_feedback_controller_params.yaml",
+                "linear_feedback_controller_simu_params.yaml",
             ]
         ),
         PathJoinSubstitution(
@@ -87,9 +87,16 @@ def launch_setup(
                 arg.name: LaunchConfiguration(arg.name)
                 for arg in generate_default_tiago_pro_args()
             },
+            "tuck_arm": "False",
+            "is_public_sim": "True",
+            "moveit": "False",
+            "play_motion2": "False",
         }.items(),
     )
 
+    # Activate all at once: ros2_control sets chained mode atomically
+    # when preceding (LFC) and following (PassthroughControllers) are
+    # activated in the same switch_controllers transaction.
     activate_controllers = ExecuteProcess(
         cmd=[
             "ros2",
@@ -111,47 +118,13 @@ def launch_setup(
         output="screen",
     )
 
-    # Track whether all events have been received.
-    tuck_arm_done = False
-    controllers_done = False
-
-    def activate_controllers_on_exit(context):
-        """Check if both tuck_arm and controller spawners have finished before activating controllers."""
-        if tuck_arm_done and controllers_done:
-            return [
-                LogInfo(msg="All conditions met. Activating controllers."),
-                activate_controllers,
-            ]
-        return []
-
-    def on_tuck_arm_exit_callback(event, context):
-        """Callback when tuck_arm.py exits."""
-        nonlocal tuck_arm_done
-        if "tuck_arm.py" in event.process_name and event.returncode == 0:
-            tuck_arm_done = True
-            return [
-                LogInfo(msg="tuck_arm.py completed. Waiting for controllers..."),
-                OpaqueFunction(function=activate_controllers_on_exit),
-            ]
-        return [LogInfo(msg="tuck_arm.py failed. Not starting controllers.")]
-
-    def on_controllers_spawned_callback(event, context):
-        """Callback when controller spawners finish."""
-        nonlocal controllers_done
-        controllers_done = True
-        return [
-            LogInfo(msg="Controllers spawned. Waiting for tuck_arm.py..."),
-            OpaqueFunction(function=activate_controllers_on_exit),
-        ]
-
     return [
         spawn_controllers,
         tiago_simulation_launch,
-        RegisterEventHandler(OnProcessExit(on_exit=on_tuck_arm_exit_callback)),
         RegisterEventHandler(
             OnProcessExit(
                 target_action=spawn_controllers.entities[2],
-                on_exit=on_controllers_spawned_callback,
+                on_exit=[activate_controllers],
             )
         ),
     ]
@@ -159,5 +132,7 @@ def launch_setup(
 
 def generate_launch_description():
     return LaunchDescription(
-        generate_default_tiago_pro_args() + [OpaqueFunction(function=launch_setup)]
+        [SetLaunchConfiguration("use_sim_time", "True")]
+        + generate_default_tiago_pro_args()
+        + [OpaqueFunction(function=launch_setup)]
     )

--- a/tiago_pro.repos
+++ b/tiago_pro.repos
@@ -17,8 +17,8 @@ repositories:
 
   vcs_tiago_pro/pal_gazebo_worlds:
     type: git
-    url: https://github.com/clementPene/pal_gazebo_worlds.git
-    version: humble-devel
+    url: https://github.com/pal-robotics/pal_gazebo_worlds.git
+    version: 4.14.1
 
   vcs_tiago_pro/pal_urdf_utils:
     type: git

--- a/tiago_pro.repos
+++ b/tiago_pro.repos
@@ -7,13 +7,18 @@ repositories:
 
   vcs_tiago_pro/pal_sea_arm_moveit_config:
     type: git
-    url: https://github.com/pal-robotics/pal_sea_arm_moveit_config.git
-    version: 1.0.5
+    url: https://github.com/clementPene/pal_sea_arm_moveit_config.git
+    version: humble-devel
 
   vcs_tiago_pro/tiago_pro_moveit_config:
     type: git
-    url: https://github.com/pal-robotics/tiago_pro_moveit_config.git
-    version: 1.5.0
+    url: https://github.com/clementPene/tiago_pro_moveit_config.git
+    version: humble-devel
+
+  vcs_tiago_pro/pal_atc:
+    type: git
+    url: https://github.com/clementPene/pal_atc.git
+    version: humble-devel
 
   vcs_tiago_pro/pal_gazebo_worlds:
     type: git

--- a/tiago_pro.repos
+++ b/tiago_pro.repos
@@ -17,8 +17,8 @@ repositories:
 
   vcs_tiago_pro/pal_gazebo_worlds:
     type: git
-    url: https://github.com/pal-robotics/pal_gazebo_worlds.git
-    version: 4.14.1
+    url: https://github.com/clementPene/pal_gazebo_worlds.git
+    version: humble-devel
 
   vcs_tiago_pro/pal_urdf_utils:
     type: git
@@ -42,18 +42,18 @@ repositories:
 
   vcs_tiago_pro/pal_sea_arm:
     type: git
-    url: https://github.com/pal-robotics/pal_sea_arm.git
-    version: 2.1.1
+    url: https://github.com/clementPene/pal_sea_arm.git
+    version: humble-devel
 
   vcs_tiago_pro/tiago_pro_robot:
     type: git
-    url: https://github.com/pal-robotics/tiago_pro_robot.git
-    version: 2.2.4
+    url: https://github.com/clementPene/tiago_pro_robot.git
+    version: humble-devel
 
   vcs_tiago_pro/tiago_pro_simulation:
     type: git
-    url: https://github.com/pal-robotics/tiago_pro_simulation.git
-    version: 1.16.0
+    url: https://github.com/clementPene/tiago_pro_simulation.git
+    version: humble-devel
 
   vcs_tiago_pro/launch_pal:
     type: git


### PR DESCRIPTION
Fix Tiago pro simulation on ignition Gazebo.

- tuck_arm , MoveIt and Nav2 disabled
- arm controller now use effort 
- LFC config improved
- spawn tiago with tucked arm
- integrate pal_atc