### PR TITLE
Added option launch_lfc to tiago_pro_common.launch.py

### DIFF
--- a/agimus_demos_common/launch/tiago_pro/tiago_pro_common.launch.py
+++ b/agimus_demos_common/launch/tiago_pro/tiago_pro_common.launch.py
@@ -39,7 +39,7 @@ def launch_setup(
     # robot_ip = LaunchConfiguration("robot_ip")
     use_gazebo = LaunchConfiguration("use_gazebo")
     use_rviz = LaunchConfiguration("use_rviz")
-    launch_lfc = LaunchConfiguration("launch_lfc")
+    launch_lfc = LaunchConfiguration("launch_lfc", default="true")
     rviz_config_path = LaunchConfiguration("rviz_config_path")
 
     use_gazebo_bool = context.perform_substitution(use_gazebo).lower() == "true"

--- a/agimus_demos_common/launch/tiago_pro/tiago_pro_common.launch.py
+++ b/agimus_demos_common/launch/tiago_pro/tiago_pro_common.launch.py
@@ -39,6 +39,7 @@ def launch_setup(
     # robot_ip = LaunchConfiguration("robot_ip")
     use_gazebo = LaunchConfiguration("use_gazebo")
     use_rviz = LaunchConfiguration("use_rviz")
+    launch_lfc = LaunchConfiguration("launch_lfc")
     rviz_config_path = LaunchConfiguration("rviz_config_path")
 
     use_gazebo_bool = context.perform_substitution(use_gazebo).lower() == "true"
@@ -159,6 +160,7 @@ def launch_setup(
             + passthrough_controllers
             + ["linear_feedback_controller", "joint_state_estimator"],
             output="screen",
+            condition=IfCondition(launch_lfc),
         )
 
         return [


### PR DESCRIPTION
Used to toogle the activation of the LFC when launching the simulation.
I use it to test/debug different start positions by publishing to the default controllers and then manually activating the LFC via the CLI.

I've only added the option to the simulation part of the launch file, since the controllers activation on the real robot is manual.